### PR TITLE
Sync state and country from CiviCRM to EO

### DIFF
--- a/includes/civicrm-event-organiser-civi.php
+++ b/includes/civicrm-event-organiser-civi.php
@@ -1610,6 +1610,8 @@ class CiviCRM_WP_Event_Organiser_CiviCRM {
 			'version' => 3,
 			'id' => $loc_id,
 			'return' => 'all',
+			// get country and state name
+			'api.Address.getsingle' => ['sequential' => 1, 'id' => "\$value.address_id", 'return' => ["country_id.name", "state_province_id.name"]],
 		);
 
 		// Call API ('get' returns an array keyed by the item).

--- a/includes/civicrm-event-organiser-eo-venue.php
+++ b/includes/civicrm-event-organiser-eo-venue.php
@@ -332,6 +332,16 @@ class CiviCRM_WP_Event_Organiser_EO_Venue {
 			//'country' => $location['address']['country'], // CiviCRM country is an ID not a string
 		);
 
+		// Add country if present.
+		if (  ! isset($location['api.Address.getsingle']['is_error']) AND ! empty( $location['api.Address.getsingle']['country_id.name'] ) ) {
+			$args['country'] = $location['api.Address.getsingle']['country_id.name'];
+		}
+
+		// Add state if present.
+		if (  ! isset($location['api.Address.getsingle']['is_error']) AND ! empty( $location['api.Address.getsingle']['state_province_id.name'] ) ) {
+			$args['state'] = $location['api.Address.getsingle']['state_province_id.name'];
+		}
+
 		// Add street address if present.
 		if ( isset( $location['address']['street_address'] ) AND ! empty( $location['address']['street_address'] ) ) {
 			$args['address'] = $location['address']['street_address'];
@@ -481,6 +491,16 @@ class CiviCRM_WP_Event_Organiser_EO_Venue {
 				//'state' => $location['address']['county'], // CiviCRM county is an ID not a string
 				//'country' => $location['address']['country'], // CiviCRM country is an ID not a string
 			);
+
+			// Add country if present.
+			if (  ! isset($location['api.Address.getsingle']['is_error']) AND ! empty( $location['api.Address.getsingle']['country_id.name'] ) ) {
+				$args['country'] = $location['api.Address.getsingle']['country_id.name'];
+			}
+
+			// Add state if present.
+			if (  ! isset($location['api.Address.getsingle']['is_error']) AND ! empty( $location['api.Address.getsingle']['state_province_id.name'] ) ) {
+				$args['state'] = $location['api.Address.getsingle']['state_province_id.name'];
+			}
 
 			// Add street address if present.
 			if ( isset( $location['address']['street_address'] ) AND ! empty( $location['address']['street_address'] ) ) {


### PR DESCRIPTION
Overview
------
CiviCRM API returns state id and country id when querying the event location.  Because of this, those two fields are not synced. 
This PR adds a chain call to get the names for state and country.

Before
-------
State and country aren't synced from CiviCRM to EO.

After
-------
State and country are synced from CiviCRM to EO.

Comment
------

Agileware ref: CIVIEO-2