### PR TITLE
Mark the post private if the CiviEvent is not public

### DIFF
--- a/includes/civicrm-event-organiser-eo.php
+++ b/includes/civicrm-event-organiser-eo.php
@@ -503,8 +503,11 @@ class CiviCRM_WP_Event_Organiser_EO {
 		$post_data['post_status'] = 'publish';
 
 		// Make the EO event a draft if the CiviEvent is not active.
+		// Not public event will be private post.
 		if ( $civi_event['is_active'] == 0 ) {
 			$post_data['post_status'] = 'draft';
+		} elseif ( $civi_event['is_public'] == 0 ) {
+			$post_data['post_status'] = 'private';
 		}
 
 		// Do we have a post ID for this event?


### PR DESCRIPTION
Overview
------
When syncing from CiviCRM to EO, the post status should reflect the CiviEvent status flags.

Before
-------
The post status is set regardless of whether the CiviEvent is active and/or public.

After
-------
The post will be marked as:
- draft if it is not active,
- published but private if it is active but not public,
- or published and public otherwise 

Comment
------

Agileware ref: CIVIEO-3